### PR TITLE
Added go_nostrip macro

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+== update version 14.9.2 ==
+
+  * Added go_nostrip macro to disable stripping of debug
+    information and to disable a debug package
+
 == update version 14.9.1 ==
 
   * simplify rpmsysinfo.rb: don't guess variables'
@@ -7,7 +12,7 @@
 
 == update version 14.9.0 ==
 
-  * Remove runtime dependency for Go API 
+  * Remove runtime dependency for Go API
 
 == update version 14.8.1 ==
 
@@ -128,7 +133,7 @@
 == Version 3 ==
 
   * skip *example*.go/*test*.go for Requires finding
-  * support alias format (import xx "xxx") for importpath 
+  * support alias format (import xx "xxx") for importpath
   * add golang-strip-builddep, a tool to strip unneeded importpath from source codes
 
 == Version 2 ==

--- a/macros.go
+++ b/macros.go
@@ -18,6 +18,10 @@
 %go_contribsrcdir  %{_datadir}/go/contrib/src/
 %go_tooldir        %{_datadir}/go/pkg/tool/linux_%{go_arch}
 
+%go_nostrip \
+%undefine _build_create_debug \
+%define __arch_install_post export NO_BRP_STRIP_DEBUG=true
+
 %go_exclusivearch \
 ExclusiveArch:  aarch64 %ix86 x86_64 %arm ppc64 ppc64le s390x
 
@@ -84,7 +88,7 @@ Provides:       %{name}-devel-static = %{version}
 #              go install importpath/baz
 #
 # See: go help install, go help packages
-%gobuild %{_prefix}/lib/rpm/golang-macros.rb --build 
+%gobuild %{_prefix}/lib/rpm/golang-macros.rb --build
 
 # Install all compiled packages and binaries to the buildroot
 %goinstall %{_prefix}/lib/rpm/golang-macros.rb --install


### PR DESCRIPTION
In order to disable stripping of Go binaries which can cause issues I
have added a new macro that can be added to our golang-\* packages which
disables the debug packages and stops stripping the debug information.
