### PR TITLE
*: always use -buildmode=pie

### DIFF
--- a/golang.sh
+++ b/golang.sh
@@ -124,7 +124,7 @@ process_build() {
     local last=$(($#-1))
   fi
 
-  local build_flags="-s -v -p 4 -x"
+  local build_flags="-s -v -p 4 -x -buildmode=pie"
   local extra_flags="${@:1:$last}"
 
   case "${modifier}" in


### PR DESCRIPTION
By default, Go builds everything as non-PIC code. This is an issue, as
ASLR is not enabled for non-PIC code and thus the usefulness of ASLR is
diminished with Go (especially since the libraries used are compiled
into the binary, giving more opportunities for ROP gadgets).

openSUSE has recently put a lot of effort into enabling -fPIC for as
many packages as possible, so we should follow suit in Go.

SUSE-Bug: https://bugzilla.suse.com/show_bug.cgi?id=1048046
Signed-off-by: Aleksa Sarai <asarai@suse.de>