### PR TITLE
golang.sh: Fix arch for aarch64

### DIFF
--- a/golang.sh
+++ b/golang.sh
@@ -67,6 +67,9 @@ process_arch() {
   "i386"|"i486"|"i586"|"i686"|"pentium3"|"pentium4"|"athlon"|"geode")
     echo "386"
     ;;
+  aarch64*)
+    echo "arm64"
+    ;;
   armv*)
     echo "arm"
     ;;


### PR DESCRIPTION
Apparently the %go_arch name to be used for AArch64 is "arm64".
Add a case in process_arch() to handle this.

Resolves issue #13.

Reported-by: Alexander Graf <agraf@suse.de>
Signed-off-by: Andreas Färber <afaerber@suse.de>