### PR TITLE
Fix the handling of quoted extra args

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== unreleased ==
+
+  * Fix the handling of quoted extra args to the gobuild and gotest macros.
+
 == update version 15.0.7 ==
 
   * golang.sh: Fix arch for aarch64

--- a/golang.sh
+++ b/golang.sh
@@ -128,20 +128,22 @@ process_build() {
   fi
 
   local build_flags="-s -v -p 4 -x -buildmode=pie"
-  local extra_flags="${@:1:$last}"
+  local extra_flags=(
+    "${@:1:$last}"
+  )
 
   case "${modifier}" in
   "...")
     GOPATH=$(get_build_path):$(get_buildcontrib_path) GOBIN=$(get_gobin_path) go \
-      install ${build_flags} ${extra_flags} $(get_import_path)...
+      install ${build_flags} "${extra_flags[@]}" $(get_import_path)...
     ;;
   "")
     GOPATH=$(get_build_path):$(get_buildcontrib_path) GOBIN=$(get_gobin_path) go \
-      install ${build_flags} ${extra_flags} $(get_import_path)
+      install ${build_flags} "${extra_flags[@]}" $(get_import_path)
     ;;
   *)
     GOPATH=$(get_build_path):$(get_buildcontrib_path) GOBIN=$(get_gobin_path) go \
-      install ${build_flags} ${extra_flags} $(get_import_path)/${modifier}
+      install ${build_flags} "${extra_flags[@]}" $(get_import_path)/${modifier}
     ;;
   esac
 }
@@ -194,10 +196,12 @@ process_test() {
     local last=$(($#-1))
   fi
 
-  local extra_flags="${@:1:$last}"
+  local extra_flags=(
+    "${@:1:$last}"
+  )
 
   GOPATH=$(get_build_path):$(get_buildcontrib_path) GOBIN=$(get_gobin_path) go \
-    test ${extra_flags} -x ${modifier}
+    test "${extra_flags[@]}" -x ${modifier}
 }
 
 process_filelist() {
@@ -225,28 +229,28 @@ main() {
 
   case "${action}" in
   "--arch"|"arch")
-    process_arch ${@:2}
+    process_arch "${@:2}"
     ;;
   "--prep"|"prep")
-    process_prepare ${@:2}
+    process_prepare "${@:2}"
     ;;
   "--build"|"build")
-    process_build ${@:2}
+    process_build "${@:2}"
     ;;
   "--install"|"install")
-    process_install ${@:2}
+    process_install "${@:2}"
     ;;
   "--source"|"source")
-    process_source ${@:2}
+    process_source "${@:2}"
     ;;
   "--test"|"test")
-    process_test ${@:2}
+    process_test "${@:2}"
     ;;
   "--filelist"|"filelist")
-    process_filelist ${@:2}
+    process_filelist "${@:2}"
     ;;
   "--godoc"|"godoc")
-    process_godoc ${@:2}
+    process_godoc "${@:2}"
     ;;
   *)
     echo "Please specify a valid method: arch, prep, build, install, source, test, filelist, godoc" >&2
@@ -254,4 +258,4 @@ main() {
   esac
 }
 
-main $@
+main "$@"


### PR DESCRIPTION
So far it was impossible to pass args containing whitespace, and thus
requiring quoting, to the %gobuild macro as the quoting was used
inconsistently. This caused the quoted arguments to be split up at the
whitespace at some point, making it impossible to e.g. pass extra
linker flags to set variable values via `-X`. This is e.g. required
when building stuff using golang-github-prometheus-common, which
expects the version information to be set via
`"-X
%{import_path}/vendor/github.com/prometheus/common/version.Version=%{version}"`.

This is the first time I am attempting to contribute to the Go packaging tools and I am not primarily a Go developer myself. Thus, I hope I am following the right process. Otherwise, if you point me in the right direction I'll be happy to push my contribution down the proper path.