### PR TITLE
Pass linker flag via ldflags

### DIFF
--- a/golang.sh
+++ b/golang.sh
@@ -127,7 +127,7 @@ process_build() {
     local last=$(($#-1))
   fi
 
-  local build_flags="-s -v -p 4 -x -buildmode=pie"
+  local build_flags="-v -p 4 -x -buildmode=pie -ldflags=-s"
   local extra_flags=(
     "${@:1:$last}"
   )


### PR DESCRIPTION
`go install` in go 1.10 does not seem to accept `-s` directly any more:

```
+ go install -s -v -p 4 -x -buildmode=pie github.com/prometheus/promu
flag provided but not defined: -s
```