### PR TITLE
fix stripping binaries

### DIFF
--- a/golang.sh
+++ b/golang.sh
@@ -127,7 +127,7 @@ process_build() {
     local last=$(($#-1))
   fi
 
-  local build_flags="-s -v -p 4 -x -buildmode=pie"
+  local build_flags="-ldflags='-s' -v -p 4 -x -buildmode=pie"
   local extra_flags=(
     "${@:1:$last}"
   )


### PR DESCRIPTION
we were passing "-s" as build parameter but this flag does not exist and
so it was giving a build error with go 1.10.

I assume "-s" was for stripping so I am passing this parameter with

ldflags=-s".

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>