### PR TITLE
Revert "Pass linker flag via ldflags"

### DIFF
--- a/golang.sh
+++ b/golang.sh
@@ -127,7 +127,7 @@ process_build() {
     local last=$(($#-1))
   fi
 
-  local build_flags="-v -p 4 -x -buildmode=pie -ldflags=-s"
+  local build_flags="-s -v -p 4 -x -buildmode=pie"
   local extra_flags=(
     "${@:1:$last}"
   )


### PR DESCRIPTION
This reverts commit 4db1d4869adf785072cb2390af6001c9e7681cef.

Explanation: https://github.com/golang/go/issues/25648

Accompanying MR: https://build.opensuse.org/request/show/613222

Go experts and especially @flavio: I am not sure whether this fix is correct or not given the behaviour of `go install` changed in 1.10:

> The go install command now installs only the packages and commands listed directly on the command line. For example, go install cmd/gofmt installs the gofmt program but not any of the packages on which it depends.
 
— https://golang.org/doc/go1.10#build


Alternative to this solution would be to drop `-s` altoghether (at least for go versions >= 1.10) and assume `go install` will do the right thing by default. I am not sure how to verify this properly at the moment.