### PR TITLE
Revert "only add the s flag if go is less than 1.10"

### DIFF
--- a/golang.sh
+++ b/golang.sh
@@ -2,19 +2,6 @@
 set -e
 set -x
 
-go_version() {
-  go version | awk '{print $3}' | sed 's/go//'
-}
-
-# version_lt exits 0 if the first version is less than the second
-# example:
-#   version_lt 1.9.3 1.10 && echo "yes"
-# will echo "yes"
-version_lt() {
- rpmdev-vercmp $1 $2 > /dev/null
- [ $? == 12 ] #rpmdev-vercmp returns 12 if the first version is less than the second
-}
-
 store_buildroot_path() {
   echo ${RPM_BUILD_ROOT} >| /tmp/buildrootpath.txt
 }
@@ -140,15 +127,7 @@ process_build() {
     local last=$(($#-1))
   fi
 
-  local build_flags="-v -p 4 -x -buildmode=pie"
-  # Add s flag if go is older than 1.10.
-  # s flag is an openSUSE flag to fix
-  #  https://bugzilla.suse.com/show_bug.cgi?id=776058
-  # This flag is added with a patch in the openSUSE package, thus it only
-  # exists in openSUSE go packages, and only on versions < 1.10.
-  # In go >= 1.10, this bug is fixed upstream and the patch that was adding the
-  # s flag has been removed from the openSUSE packages.
-  version_lt go_version 1.10 && build_flags="-s $build_flags"
+  local build_flags="-s -v -p 4 -x -buildmode=pie"
   local extra_flags=(
     "${@:1:$last}"
   )


### PR DESCRIPTION
This reverts commit ee39c2073d8403cc88e8e3ac0bc34ea36c5fe6e2.

I merged this by mistake