### PR TITLE
Don't throw an error on prep if $(get_gocontrib_path) does not exist.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+   * golang.sh: Don't throw an error on prep if $(get_gocontrib_path) does not exist.
+
 == update version 15.0.13 ==
 
    * golang.sh: Preserve modification time of source files for reproducible builds

--- a/golang.sh
+++ b/golang.sh
@@ -111,7 +111,7 @@ process_prepare() {
   cp -rpT $(pwd) $(get_destination_path)/
 
   echo "Copying deps to $(get_buildcontrib_path)"
-  cp -rpT $(get_gocontrib_path)/src $(get_buildcontrib_path)/src
+  cp -rpT $(get_gocontrib_path)/src $(get_buildcontrib_path)/src || :
 }
 
 process_build() {


### PR DESCRIPTION
It is not guaranteed that $(get_gocontrib_path)/src exists.
Don't throw an error if the folder is not found but continue.